### PR TITLE
Custum err 新增对自定义消息错误码的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+open_im_sdk_server
+./idea

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ BIN_DIR=../../bin/
 LAN_FILE=.go
 GO_FILE:=${BINARY_NAME}${LAN_FILE}
 
+build-linux:
+	go mod tidy
+	CGO_ENABLED=1 go build -o open_im_sdk_server ws_wrapper/cmd/open_im_sdk_server.go
+
 build:
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o ${BINARY_NAME}  ${GO_FILE}
 install:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/minio/minio-go/v7 v7.0.22
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/pkg/errors v0.9.1
-	github.com/pkg/profile v1.6.0
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/shamsher31/goimgext v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
-github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=

--- a/internal/interaction/ws.go
+++ b/internal/interaction/ws.go
@@ -2,8 +2,6 @@ package interaction
 
 import (
 	"errors"
-	"github.com/golang/protobuf/proto"
-	"github.com/gorilla/websocket"
 	"open_im_sdk/pkg/common"
 	"open_im_sdk/pkg/constant"
 	"open_im_sdk/pkg/log"
@@ -11,6 +9,9 @@ import (
 	"open_im_sdk/pkg/utils"
 	"open_im_sdk/sdk_struct"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/gorilla/websocket"
 )
 
 type Ws struct {
@@ -48,6 +49,10 @@ func (w *Ws) WaitResp(ch chan GeneralWsResp, timeout int, operationID string, co
 	case r := <-ch:
 		log.Debug(operationID, "ws ch recvMsg success, code ", r.ErrCode)
 		if r.ErrCode != 0 {
+			// 首先判断是否是自定义的错误码区间【拦截器】
+			if r.ErrCode >= constant.ErrCodeFilterMin && r.ErrCode <= constant.ErrCodeFilterMax {
+				return nil, common.NewCodeError(r.ErrCode, r.ErrMsg)
+			}
 			log.Error(operationID, "ws ch recvMsg failed, code, err msg: ", r.ErrCode, r.ErrMsg)
 			switch r.ErrCode {
 			case int(constant.ErrInBlackList.ErrCode):

--- a/pkg/common/wrap_error.go
+++ b/pkg/common/wrap_error.go
@@ -1,10 +1,29 @@
 package common
 
 import (
-	"github.com/mitchellh/mapstructure"
 	"open_im_sdk/open_im_sdk_callback"
 	"open_im_sdk/pkg/db"
+
+	"github.com/mitchellh/mapstructure"
 )
+
+// 带有错误码的error
+type CodeError struct {
+	Code int
+	Msg  string
+}
+
+func (e *CodeError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Msg
+}
+
+// 使用特定的code和消息构造一个CodeError
+func NewCodeError(code int, msg string) error {
+	return &CodeError{Code: code, Msg: msg}
+}
 
 func GetGroupMemberListByGroupID(callback open_im_sdk_callback.Base, operationID string, db *db.DataBase, groupID string) []*db.LocalGroupMember {
 	memberList, err := db.GetGroupMemberListByGroupID(groupID)

--- a/pkg/constant/error.go
+++ b/pkg/constant/error.go
@@ -41,6 +41,14 @@ var (
 	ErrNotSupportFunction      = ErrInfo{ErrCode: 906, ErrMsg: NotSupportFunction.Error()}
 )
 
+const (
+	// 自定义的过滤器错误码最小值
+	ErrCodeFilterMin = 10001
+
+	// 自定义的过滤器错误码大值
+	ErrCodeFilterMax = 11000
+)
+
 var (
 	ParseTokenMsg       = errors.New("parse token failed")
 	TokenExpiredMsg     = errors.New("token is timed out, please log in again")

--- a/pkg/constant/error.go
+++ b/pkg/constant/error.go
@@ -43,10 +43,10 @@ var (
 
 const (
 	// 自定义的过滤器错误码最小值
-	ErrCodeFilterMin = 10001
+	ErrCodeFilterMin = 30001
 
 	// 自定义的过滤器错误码大值
-	ErrCodeFilterMax = 11000
+	ErrCodeFilterMax = 39999
 )
 
 var (


### PR DESCRIPTION
在发送消息时，自定义的拦截器callback这些逻辑中会有一部分自定义错误消息需要提示用户的情况，现在定了一段code区间开放给这些callback，支持处于该区间的错误消息，原生返回给用户（在原有的逻辑中，错误消息大部分都被处理成了302）