### PR TITLE
fix: 更新会话已读应该回调OnConversationChanged而非OnNewConversation

### DIFF
--- a/internal/conversation_msg/conversation_msg.go
+++ b/internal/conversation_msg/conversation_msg.go
@@ -1737,7 +1737,7 @@ func (c *Conversation) doUpdateConversation(c2v common.Cmd2Value) {
 		}
 		if result != nil {
 			log.Info("internal", "getMultipleConversationModel success :", result)
-			c.ConversationListener.OnNewConversation(utils.StructToJsonString(result))
+			c.ConversationListener.OnConversationChanged(utils.StructToJsonString(result))
 		}
 	case constant.SyncConversation:
 		operationID := node.Args.(string)


### PR DESCRIPTION
这个问题导致 Open-IM-Flutter-Demo 项目在会话列表产生多个相同的会话