### PR TITLE
fix: rIssue with Asset Uploading for Official Releases in GoReleaser Action v4 - release openim version not auto build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,31 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 
+
+
+git:
+  # What should be used to sort tags when gathering the current and previous
+  # tags if there are more than one tag in the same commit.
+  #
+  # Default: '-version:refname'
+  tag_sort: -version:creatordate
+
+  # What should be used to specify prerelease suffix while sorting tags when gathering
+  # the current and previous tags if there are more than one tag in the same commit.
+  #
+  # Since: v1.17
+  prerelease_suffix: "-"
+
+  # Tags to be ignored by GoReleaser.
+  # This means that GoReleaser will not pick up tags that match any of the
+  # provided values as either previous or current tags.
+  #
+  # Templates: allowed.
+  # Since: v1.21.
+  ignore_tags:
+    - nightly
+    # - "{{.Env.IGNORE_TAG}}"
+
 report_sizes: true
 
 builds:


### PR DESCRIPTION
I'm currently experiencing a problem with the GoReleaser Action v4 in our GitHub Actions workflow, specifically when releasing different types of versions. While pre-releases such as v3.5.1.beta.0 are being published successfully, the action encounters failures during the publishing of official releases (e.g., v3.5.1).

🔍 What type of PR is this?
/kind documentation
/kind feature

resolves openimsdk/open-im-server#1660

👀 What this PR does / why we need it:
 My pull request adheres to the code style of this project
 My code requires changes to the documentation
 I have updated the documentation as required
 All the tests have passed
The issue is evident in the 'release actions' job of our workflow. Detailed information and logs can be found here: [Release Actions Job](https://github.com/openimsdk/chat/actions/runs/7364259821/job/20044473138)
