### PR TITLE
fix: search message do not filter voice message when keyword is empty.

### DIFF
--- a/internal/conversation_msg/conversation.go
+++ b/internal/conversation_msg/conversation.go
@@ -496,6 +496,8 @@ func (c *Conversation) filterMsg(temp *sdk_struct.MsgStruct, searchParam *sdk.Se
 		}
 	case constant.Picture:
 		fallthrough
+	case constant.Sound:
+		fallthrough
 	case constant.Video:
 		if len(searchParam.KeywordList) == 0 {
 			return false


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #817 
