### PR TITLE
fix: Resolved the issue where the delete message method only performs local deletion when the seq is 0 in pre-release-v3.8.4.

### DIFF
--- a/internal/conversation_msg/delete.go
+++ b/internal/conversation_msg/delete.go
@@ -120,18 +120,22 @@ func (c *Conversation) deleteMessage(ctx context.Context, conversationID string,
 	if err != nil {
 		return err
 	}
+
 	localMessage, err := c.db.GetMessage(ctx, conversationID, clientMsgID)
 	if err != nil {
 		return err
 	}
+
 	if localMessage.Status == constant.MsgStatusSendFailed {
 		log.ZInfo(ctx, "delete msg status is send failed, do not need delete", "msg", localMessage)
 		return nil
 	}
+
 	if localMessage.Seq == 0 {
-		log.ZInfo(ctx, "delete msg seq is 0, try again", "msg", localMessage)
-		return sdkerrs.ErrMsgHasNoSeq
+		log.ZInfo(ctx, "delete msg seq is 0, only delete in local", "msg", localMessage)
+		return c.deleteMessageFromLocal(ctx, conversationID, clientMsgID)
 	}
+
 	err = c.deleteMessagesFromServer(ctx, conversationID, []int64{localMessage.Seq})
 	if err != nil {
 		return err


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #1025
